### PR TITLE
Remove 404 GHCR link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 ## Public repositories
 
-- [ghcr.io/sorah-rbpkg/ruby](https://github.com/sorah-rbpkg/dockerfiles/pkgs/container/ruby)
 - [public.ecr.aws/sorah/ruby](https://gallery.ecr.aws/sorah/ruby)
 - [sorah/ruby](https://hub.docker.com/r/sorah/ruby) _(deprecated, no longer guaranteed to be updated)_
 


### PR DESCRIPTION
I happened to come across this repository during work and noticed that this link returns 404.

Since I am not familiar with the historical context of this project, I am not entirely sure, but does this mean that the GHCR version is no longer maintained? If so, I thought the link should be removed.

<img width="1324" height="992" alt="image" src="https://github.com/user-attachments/assets/698addcc-b0c5-479b-8bba-4f1e0299b7a0" />
